### PR TITLE
Use xbuild with mono on Linux

### DIFF
--- a/src/R/rDotNet/R/Driver.R
+++ b/src/R/rDotNet/R/Driver.R
@@ -57,10 +57,10 @@
         {
             if (.Platform$OS.type != "windows")
             {
-                paths <- c("/usr/bin/mono64","/usr/local/bin/mono64","/Library/Frameworks/Mono.framework/Commands/mono64")
+                paths <- c("/usr/bin/mono", "/usr/bin/mono64","/usr/local/bin/mono64","/Library/Frameworks/Mono.framework/Commands/mono64")
                 mono <- paths[sapply(paths, file.exists)][1]
                 if (is.null(mono))
-                    stop ("could not find mono64")
+                    stop ("could not find mono or mono64")
             }
         
             packagedir <- path.package("rDotNet")

--- a/src/R/rDotNet/R/Initialize.R
+++ b/src/R/rDotNet/R/Initialize.R
@@ -16,9 +16,9 @@
         return ()
     }
     
-    if (Sys.which("msbuild") == "")
+    if (Sys.which("msbuild") == "" && Sys.which("xbuild") == "")
     {
-        warning ("could not find msbuild in path; will not be able to use rDotNet unless corrected and rebuilt")
+        warning ("could not find msbuild or xbuild in path; will not be able to use rDotNet unless corrected and rebuilt")
         return()
     }
     
@@ -29,7 +29,7 @@
     system2 ("nuget", "restore", wait=TRUE, stderr=TRUE, stdout=TRUE)
         
     packageStartupMessage ("building project")
-    system2 ("msbuild", wait=TRUE, stderr=TRUE, stdout=TRUE)
+    system2 (ifelse(Sys.which("msbuild") != "", "msbuild", "xbuild"), wait=TRUE, stderr=TRUE, stdout=TRUE)
 
     setwd(cwd)
 }


### PR DESCRIPTION
According to http://www.mono-project.com/docs/tools+libraries/tools/xbuild/ Mono's implementation of msbuild is called xbuild. This commit just checks for xbuild incase msbuild is not found (which seems to be the case on Fedora at least) and then uses it for building the package. I was able to get rDotNet built and installed on Linux with this change.